### PR TITLE
Account Settings : Added Change Password, Name and Avatar Update Functionality

### DIFF
--- a/src/main/java/com/eternalcoders/pointedge/controller/EmployeeController.java
+++ b/src/main/java/com/eternalcoders/pointedge/controller/EmployeeController.java
@@ -10,8 +10,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -52,6 +54,33 @@ public class EmployeeController {
         }
         return ResponseEntity.status(401).body("Unauthorized");
     }
+
+    @PostMapping("/update-profile")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<String> updateProfile(@RequestBody EmployeeDTO dto, Principal principal) {
+        String email = principal.getName();
+        employeeService.updateNameAndAvatar(email, dto.getName(), dto.getAvatar());
+        return ResponseEntity.ok("Profile updated successfully");
+    }
+
+    @PostMapping("/change-password")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<String> changePassword(@RequestBody EmployeeDTO dto, Principal principal) {
+        String email = principal.getName();
+
+        // Validate input passwords from dto
+        String currentPassword = dto.getConfirmPassword();  // use confirmPassword field as current password
+        String newPassword = dto.getTempPassword();         // use tempPassword field as new password
+
+        if (currentPassword == null || newPassword == null || currentPassword.isBlank() || newPassword.isBlank()) {
+            return ResponseEntity.badRequest().body("Current and new password must be provided");
+        }
+
+        employeeService.changePassword(email, currentPassword, newPassword);
+        return ResponseEntity.ok("Password changed successfully");
+    }
+
+
 
     @GetMapping
     public ResponseEntity<List<EmployeeDTO>> getAllEmployees() {

--- a/src/main/java/com/eternalcoders/pointedge/entity/Employee.java
+++ b/src/main/java/com/eternalcoders/pointedge/entity/Employee.java
@@ -1,16 +1,15 @@
 package com.eternalcoders.pointedge.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
 @Entity
 @Table(name = "employees")
 @Data
+@Setter
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Employee {
@@ -31,10 +30,8 @@ public class Employee {
     private String phoneNumber;
 
     @Column(nullable = false)
-    private String name; 
+    private String name;
 
-    // Auth Info
-    @Setter
     private String tempPassword;
 
     // Role and avatar

--- a/src/main/java/com/eternalcoders/pointedge/service/EmployeeService.java
+++ b/src/main/java/com/eternalcoders/pointedge/service/EmployeeService.java
@@ -62,6 +62,35 @@ public class EmployeeService {
         // Logic for resetting the password using token
     }
 
+    public void updateNameAndAvatar(String email, String name, String avatar) {
+        Employee employee = employeeRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee not found"));
+
+        if (name != null && !name.isBlank()) {
+            employee.setName(name);
+        }
+
+        if (avatar != null && !avatar.isBlank()) {
+            employee.setAvatar(avatar);
+        }
+
+        if ((name != null && !name.isBlank()) || (avatar != null && !avatar.isBlank())) {
+            employeeRepository.save(employee);
+        }
+    }
+
+    public void changePassword(String email, String currentPassword, String newPassword) {
+        Employee employee = employeeRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee not found"));
+
+        if (!passwordEncoder.matches(currentPassword, employee.getTempPassword())) {
+            throw new RuntimeException("Current password is incorrect");
+        }
+
+        employee.setTempPassword(passwordEncoder.encode(newPassword));
+        employeeRepository.save(employee);
+    }
+
     public List<Employee> getAllEmployees() {
         return employeeRepository.findAll();
     }

--- a/src/main/java/com/eternalcoders/pointedge/service/EmployeeService.java
+++ b/src/main/java/com/eternalcoders/pointedge/service/EmployeeService.java
@@ -99,4 +99,33 @@ public class EmployeeService {
     public List<Employee> findByStatus(Employee.EmployeeStatus status) {
         return employeeRepository.findByStatus(status);
     }
+
+    public void updateNameAndAvatar(String email, String name, String avatar) {
+        Employee employee = employeeRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee not found"));
+
+        if (name != null && !name.isBlank()) {
+            employee.setName(name);
+        }
+
+        if (avatar != null && !avatar.isBlank()) {
+            employee.setAvatar(avatar);
+        }
+
+        if ((name != null && !name.isBlank()) || (avatar != null && !avatar.isBlank())) {
+            employeeRepository.save(employee);
+        }
+    }
+
+    public void changePassword(String email, String currentPassword, String newPassword) {
+        Employee employee = employeeRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee not found"));
+
+        if (!passwordEncoder.matches(currentPassword, employee.getTempPassword())) {
+            throw new RuntimeException("Current password is incorrect");
+        }
+
+        employee.setTempPassword(passwordEncoder.encode(newPassword));
+        employeeRepository.save(employee);
+    }
 }


### PR DESCRIPTION
- Implemented **Account Settings** feature with backend support for
  - Changing employee's password securely with validation.
  - Updating employee's name and/or avatar independently.
  - Handled validations and error responses.

Changes Included
- `EmployeeController`:
  - Added `/update-profile` endpoint for updating name or avatar.
  - Added `/change-password` endpoint for password update with validation.
  
- `EmployeeService`
  - Enhanced `updateNameAndAvatar()` to allow partial updates.
  - Implemented `changePassword()` with current password verification and encryption.

- Cleaned up minor validations and added null/blank checks.

Validation
- Tested both endpoints via Postman & frontend integration.
- Ensured role-based access with `@PreAuthorize`.
